### PR TITLE
feat: wire up GirafAIClient and fix generate flow

### DIFF
--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -61,17 +61,35 @@ class PictogramService:
         generate_image: bool = False,
         generate_sound: bool = True,
     ) -> Pictogram:
-        try:
-            pictogram = Pictogram.objects.create(
+        if generate_image and not image_url:
+            # Skip model validation — image will be populated by AI generation.
+            pictogram = Pictogram(
                 name=name,
                 image_url=image_url,
                 organization_id=organization_id,
             )
-        except DjangoValidationError as e:
-            raise BusinessValidationError(" ".join(e.messages))
+            super(Pictogram, pictogram).save()
 
-        if generate_image:
             PictogramService._try_generate_image(pictogram, name)
+
+            # If AI generation failed, the pictogram has no image — validate now.
+            if not pictogram.image and not pictogram.image_url:
+                pictogram.delete()
+                raise BusinessValidationError(
+                    "Image generation failed and no image_url was provided."
+                )
+        else:
+            try:
+                pictogram = Pictogram.objects.create(
+                    name=name,
+                    image_url=image_url,
+                    organization_id=organization_id,
+                )
+            except DjangoValidationError as e:
+                raise BusinessValidationError(" ".join(e.messages))
+
+            if generate_image:
+                PictogramService._try_generate_image(pictogram, name)
 
         if generate_sound:
             PictogramService._try_generate_sound(pictogram)

--- a/core/clients/giraf_ai.py
+++ b/core/clients/giraf_ai.py
@@ -1,6 +1,10 @@
-"""Stubbed client for the giraf-ai service."""
+"""HTTP client for the giraf-ai image/TTS generation service."""
 
+import base64
+import json
 import logging
+import urllib.request
+import urllib.error
 
 from django.conf import settings
 
@@ -12,17 +16,54 @@ logger = logging.getLogger(__name__)
 class GirafAIClient:
     """Client for the giraf-ai image/TTS generation service.
 
-    Currently stubbed — all methods raise GirafAIUnavailableError.
-    Will be implemented when giraf-ai is deployed.
+    Calls giraf-ai's REST API for image generation and TTS.
+    Raises GirafAIUnavailableError when GIRAF_AI_URL is not configured
+    or the service is unreachable.
     """
 
     def __init__(self):
-        self.base_url = getattr(settings, "GIRAF_AI_URL", "")
+        self.base_url = getattr(settings, "GIRAF_AI_URL", "").rstrip("/")
+
+    def _post(self, path: str, body: dict) -> dict:
+        """Make a POST request to giraf-ai and return the parsed JSON response."""
+        if not self.base_url:
+            raise GirafAIUnavailableError("GIRAF_AI_URL is not configured.")
+
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode()
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return json.loads(resp.read())
+        except urllib.error.URLError as exc:
+            raise GirafAIUnavailableError(
+                f"giraf-ai service is unreachable: {exc}"
+            ) from exc
+        except Exception as exc:
+            raise GirafAIUnavailableError(
+                f"giraf-ai request failed: {exc}"
+            ) from exc
 
     def generate_image(self, prompt: str) -> bytes:
         """Generate an image from a text prompt. Returns raw image bytes (PNG)."""
-        raise GirafAIUnavailableError("giraf-ai service is not yet available.")
+        result = self._post("/api/v1/generate/image", {
+            "prompt": prompt,
+            "style": "pictogram",
+            "format": "png",
+        })
+        return base64.b64decode(result["image_base64"])
 
     def generate_tts(self, text: str) -> bytes:
         """Generate TTS audio from text. Returns raw audio bytes (MP3)."""
-        raise GirafAIUnavailableError("giraf-ai service is not yet available.")
+        result = self._post("/api/v1/tts", {
+            "text": text,
+            "language": "da",
+            "format": "mp3",
+        })
+        return base64.b64decode(result["audio_base64"])


### PR DESCRIPTION
Replaces stubbed AI client with real HTTP calls. Fixes validation error when creating pictograms with generate_image=True.