### PR TITLE
fix: add search parameter to pictogram list endpoint

### DIFF
--- a/apps/pictograms/api.py
+++ b/apps/pictograms/api.py
@@ -32,11 +32,11 @@ def create_pictogram(request, payload: PictogramCreateIn):
 
 @router.get("", response=list[PictogramOut])
 @paginate(LimitOffsetPagination)
-def list_pictograms(request, organization_id: int | None = None):
-    """List pictograms. Returns global + org-specific if org_id provided (requires membership)."""
+def list_pictograms(request, organization_id: int | None = None, search: str | None = None):
+    """List pictograms. Optionally filter by search term and/or organization."""
     if organization_id:
         check_role_or_raise(request.auth, organization_id, min_role=OrgRole.MEMBER)
-    return PictogramService.list_pictograms(organization_id)
+    return PictogramService.list_pictograms(organization_id, search=search)
 
 
 @router.post("/upload", response={201: PictogramOut, 403: ErrorOut, 422: ErrorOut})

--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -97,10 +97,14 @@ class PictogramService:
         return pictogram
 
     @staticmethod
-    def list_pictograms(organization_id: int | None = None) -> QuerySet[Pictogram]:
+    def list_pictograms(organization_id: int | None = None, search: str | None = None) -> QuerySet[Pictogram]:
         if organization_id:
-            return Pictogram.objects.filter(Q(organization_id=organization_id) | Q(organization__isnull=True))
-        return Pictogram.objects.filter(organization__isnull=True)
+            qs = Pictogram.objects.filter(Q(organization_id=organization_id) | Q(organization__isnull=True))
+        else:
+            qs = Pictogram.objects.filter(organization__isnull=True)
+        if search:
+            qs = qs.filter(name__icontains=search)
+        return qs
 
     @staticmethod
     def get_pictogram(pictogram_id: int) -> Pictogram:

--- a/apps/pictograms/tests/test_api.py
+++ b/apps/pictograms/tests/test_api.py
@@ -71,6 +71,34 @@ class TestPictogramAPI:
         assert "Global" in names
         assert "Org Specific" in names
 
+    def test_list_pictograms_search_filters_results(self, client, org, member):
+        from apps.pictograms.models import Pictogram
+
+        Pictogram.objects.create(name="Cat", image_url="https://c.com/c.png", organization=org)
+        Pictogram.objects.create(name="Dog", image_url="https://d.com/d.png", organization=org)
+        Pictogram.objects.create(name="Caterpillar", image_url="https://cp.com/cp.png", organization=org)
+
+        headers = auth_header_for_user(member)
+        response = client.get(f"/api/v1/pictograms?organization_id={org.id}&search=cat", **headers)
+        assert response.status_code == 200
+        names = [p["name"] for p in response.json()["items"]]
+        assert "Cat" in names
+        assert "Caterpillar" in names
+        assert "Dog" not in names
+
+    def test_list_pictograms_empty_search_returns_all(self, client, org, member):
+        from apps.pictograms.models import Pictogram
+
+        Pictogram.objects.create(name="Cat", image_url="https://c.com/c.png", organization=org)
+        Pictogram.objects.create(name="Dog", image_url="https://d.com/d.png", organization=org)
+
+        headers = auth_header_for_user(member)
+        response = client.get(f"/api/v1/pictograms?organization_id={org.id}&search=", **headers)
+        assert response.status_code == 200
+        names = [p["name"] for p in response.json()["items"]]
+        assert "Cat" in names
+        assert "Dog" in names
+
     def test_get_pictogram(self, client, org, member):
         from apps.pictograms.models import Pictogram
 

--- a/apps/pictograms/tests/test_services.py
+++ b/apps/pictograms/tests/test_services.py
@@ -163,3 +163,48 @@ class TestPictogramServiceErrors:
         names = [p.name for p in results]
         assert "Global" in names
         assert "OrgOnly" not in names
+
+
+@pytest.mark.django_db
+class TestPictogramServiceSearch:
+    def test_search_filters_by_name(self):
+        PictogramService.create_pictogram(name="Cat", image_url="http://c.png", generate_sound=False)
+        PictogramService.create_pictogram(name="Dog", image_url="http://d.png", generate_sound=False)
+        PictogramService.create_pictogram(name="Caterpillar", image_url="http://cp.png", generate_sound=False)
+
+        results = list(PictogramService.list_pictograms(search="cat"))
+        names = [p.name for p in results]
+        assert "Cat" in names
+        assert "Caterpillar" in names
+        assert "Dog" not in names
+
+    def test_search_is_case_insensitive(self):
+        PictogramService.create_pictogram(name="cat", image_url="http://c.png", generate_sound=False)
+
+        results = list(PictogramService.list_pictograms(search="CAT"))
+        assert len(results) == 1
+        assert results[0].name == "cat"
+
+    def test_search_no_match_returns_empty(self):
+        PictogramService.create_pictogram(name="Cat", image_url="http://c.png", generate_sound=False)
+
+        results = list(PictogramService.list_pictograms(search="xyz"))
+        assert len(results) == 0
+
+    def test_search_with_org_filters_both(self):
+        from apps.organizations.models import Organization
+
+        org = Organization.objects.create(name="Test School")
+        PictogramService.create_pictogram(name="Cat Global", image_url="http://cg.png", generate_sound=False)
+        PictogramService.create_pictogram(
+            name="Cat Org", image_url="http://co.png", organization_id=org.id, generate_sound=False
+        )
+        PictogramService.create_pictogram(
+            name="Dog Org", image_url="http://do.png", organization_id=org.id, generate_sound=False
+        )
+
+        results = list(PictogramService.list_pictograms(organization_id=org.id, search="cat"))
+        names = [p.name for p in results]
+        assert "Cat Global" in names
+        assert "Cat Org" in names
+        assert "Dog Org" not in names


### PR DESCRIPTION
## Summary

- Adds `search` query parameter to `GET /api/v1/pictograms` that filters by pictogram name using case-insensitive substring matching (`icontains`)
- The weekplanner frontend already sends this parameter but it was silently dropped by Django Ninja

## Changes

- `apps/pictograms/api.py`: Accept `search` query param, pass to service
- `apps/pictograms/services.py`: Apply `name__icontains` filter when `search` is provided
- Tests: 4 service-layer + 2 API-layer tests covering filtering, case insensitivity, no-match, combined org+search, and empty search

## Test plan

- [x] All 233 tests pass (`uv run pytest`)
- [x] New tests verified via TDD (watched fail before implementing)

Closes #9