### PR TITLE
chore: expand ruff lint rules and fix all violations

### DIFF
--- a/apps/citizens/services.py
+++ b/apps/citizens/services.py
@@ -12,8 +12,8 @@ class CitizenService:
     def _get_citizen_or_raise(citizen_id: int) -> Citizen:
         try:
             return Citizen.objects.select_related("organization").get(id=citizen_id)
-        except Citizen.DoesNotExist:
-            raise ResourceNotFoundError(f"Citizen {citizen_id} not found.")
+        except Citizen.DoesNotExist as e:
+            raise ResourceNotFoundError(f"Citizen {citizen_id} not found.") from e
 
     @staticmethod
     @transaction.atomic

--- a/apps/grades/services.py
+++ b/apps/grades/services.py
@@ -13,8 +13,8 @@ class GradeService:
     def _get_grade_or_raise(grade_id: int) -> Grade:
         try:
             return Grade.objects.select_related("organization").get(id=grade_id)
-        except Grade.DoesNotExist:
-            raise ResourceNotFoundError(f"Grade {grade_id} not found.")
+        except Grade.DoesNotExist as e:
+            raise ResourceNotFoundError(f"Grade {grade_id} not found.") from e
 
     @staticmethod
     def _validate_citizens_belong_to_org(citizen_ids: list[int], org_id: int) -> None:

--- a/apps/invitations/services.py
+++ b/apps/invitations/services.py
@@ -24,8 +24,8 @@ class InvitationService:
             qs = qs.select_for_update()
         try:
             return qs.get(id=invitation_id)
-        except Invitation.DoesNotExist:
-            raise ResourceNotFoundError(f"Invitation {invitation_id} not found.")
+        except Invitation.DoesNotExist as e:
+            raise ResourceNotFoundError(f"Invitation {invitation_id} not found.") from e
 
     @staticmethod
     def get_invitation(invitation_id: int) -> Invitation:
@@ -43,7 +43,7 @@ class InvitationService:
         try:
             receiver = User.objects.get(email=receiver_email)
         except (User.DoesNotExist, User.MultipleObjectsReturned):
-            raise InvitationSendError("Cannot send invitation.")
+            raise InvitationSendError("Cannot send invitation.") from None
 
         if Membership.objects.filter(user=receiver, organization_id=org_id).exists():
             raise InvitationSendError("Cannot send invitation.")
@@ -55,7 +55,7 @@ class InvitationService:
                 receiver=receiver,
             )
         except IntegrityError:
-            raise DuplicateInvitationError("Pending invitation already exists.")
+            raise DuplicateInvitationError("Pending invitation already exists.") from None
 
         logger.info("Invitation sent: id=%d org=%d sender=%d receiver=%d", inv.id, org_id, sender_id, receiver.id)
         return Invitation.objects.select_related("organization", "sender", "receiver").get(id=inv.id)

--- a/apps/organizations/services.py
+++ b/apps/organizations/services.py
@@ -26,8 +26,8 @@ class OrganizationService:
     def _get_org_or_raise(org_id: int) -> Organization:
         try:
             return Organization.objects.get(id=org_id)
-        except Organization.DoesNotExist:
-            raise ResourceNotFoundError("Organization not found.")
+        except Organization.DoesNotExist as e:
+            raise ResourceNotFoundError("Organization not found.") from e
 
     @staticmethod
     def get_organization(org_id: int) -> Organization:
@@ -94,8 +94,8 @@ class OrganizationService:
 
         try:
             membership = Membership.objects.get(organization_id=org_id, user_id=target_user_id)
-        except Membership.DoesNotExist:
-            raise ResourceNotFoundError("Member not found in this organization.")
+        except Membership.DoesNotExist as e:
+            raise ResourceNotFoundError("Member not found in this organization.") from e
 
         OrganizationService._check_last_owner(org_id, membership)
 
@@ -113,8 +113,8 @@ class OrganizationService:
 
         try:
             membership = Membership.objects.get(organization_id=org_id, user_id=target_user_id)
-        except Membership.DoesNotExist:
-            raise ResourceNotFoundError("Member not found in this organization.")
+        except Membership.DoesNotExist as e:
+            raise ResourceNotFoundError("Member not found in this organization.") from e
 
         OrganizationService._check_last_owner(org_id, membership)
 

--- a/apps/organizations/tests/test_models.py
+++ b/apps/organizations/tests/test_models.py
@@ -5,6 +5,7 @@ Written BEFORE implementation — defines the expected domain behavior.
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from apps.users.tests.factories import UserFactory
@@ -25,7 +26,7 @@ class TestOrganizationModel:
     def test_organization_name_required(self):
         from apps.organizations.models import Organization
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             Organization.objects.create(name="")
 
 

--- a/apps/pictograms/models.py
+++ b/apps/pictograms/models.py
@@ -70,8 +70,8 @@ class Pictogram(models.Model):
 
             try:
                 citizen = Citizen.objects.get(pk=self.citizen_id)
-            except Citizen.DoesNotExist:
-                raise ValidationError("Citizen does not exist.")
+            except Citizen.DoesNotExist as e:
+                raise ValidationError("Citizen does not exist.") from e
             if citizen.organization_id != self.organization_id:
                 raise ValidationError("Citizen must belong to the pictogram's organization.")
 

--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -24,8 +24,8 @@ class PictogramService:
     def _get_pictogram_or_raise(pictogram_id: int) -> Pictogram:
         try:
             return Pictogram.objects.get(id=pictogram_id)
-        except Pictogram.DoesNotExist:
-            raise ResourceNotFoundError(f"Pictogram {pictogram_id} not found.")
+        except Pictogram.DoesNotExist as e:
+            raise ResourceNotFoundError(f"Pictogram {pictogram_id} not found.") from e
 
     @staticmethod
     def _try_generate_sound(pictogram: Pictogram) -> None:
@@ -103,7 +103,7 @@ class PictogramService:
                     citizen_id=citizen_id,
                 )
             except DjangoValidationError as e:
-                raise BusinessValidationError(" ".join(e.messages))
+                raise BusinessValidationError(" ".join(e.messages)) from e
 
             if generate_image:
                 PictogramService._try_generate_image(pictogram, name)

--- a/apps/pictograms/tests/test_services.py
+++ b/apps/pictograms/tests/test_services.py
@@ -234,7 +234,7 @@ class TestPictogramServiceCitizenScope:
         assert p.organization_id == org.id
 
     def test_create_citizen_scoped_requires_org(self):
-        org, citizen = self._make_org_and_citizen()
+        _org, citizen = self._make_org_and_citizen()
         with pytest.raises(BusinessValidationError, match="require"):
             PictogramService.create_pictogram(
                 name="Bad",
@@ -246,7 +246,7 @@ class TestPictogramServiceCitizenScope:
     def test_create_citizen_scoped_wrong_org(self):
         from apps.organizations.models import Organization
 
-        org_a, citizen = self._make_org_and_citizen()
+        _org_a, citizen = self._make_org_and_citizen()
         org_b = Organization.objects.create(name="Other School")
         with pytest.raises(BusinessValidationError, match="does not belong"):
             PictogramService.create_pictogram(

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -21,8 +21,8 @@ class UserService:
     def _get_user_or_raise(user_id: int) -> User:
         try:
             return User.objects.get(id=user_id)
-        except User.DoesNotExist:
-            raise ResourceNotFoundError(f"User {user_id} not found.")
+        except User.DoesNotExist as e:
+            raise ResourceNotFoundError(f"User {user_id} not found.") from e
 
     @staticmethod
     @transaction.atomic
@@ -42,7 +42,7 @@ class UserService:
         try:
             validate_password(password)
         except DjangoValidationError as e:
-            raise BusinessValidationError(e.messages)
+            raise BusinessValidationError(e.messages) from e
 
         user = User.objects.create_user(
             username=username,
@@ -93,7 +93,7 @@ class UserService:
         try:
             validate_password(new_password)
         except DjangoValidationError as e:
-            raise BusinessValidationError(e.messages)
+            raise BusinessValidationError(e.messages) from e
 
         user.set_password(new_password)
         user.save()

--- a/apps/users/tests/test_jwt_claims.py
+++ b/apps/users/tests/test_jwt_claims.py
@@ -70,7 +70,7 @@ class TestJWTOrgRoleClaims:
 
     def test_login_response_includes_org_roles(self, client, user, orgs_with_roles):
         """The /token/pair JSON response body also includes org_roles."""
-        org_a, org_b, org_c = orgs_with_roles
+        org_a, _org_b, _org_c = orgs_with_roles
         tokens = login(client)
 
         assert "org_roles" in tokens
@@ -78,7 +78,7 @@ class TestJWTOrgRoleClaims:
 
     def test_org_roles_update_after_role_change(self, client, user, orgs_with_roles):
         """After a role change, a new token should reflect the updated role."""
-        org_a, org_b, org_c = orgs_with_roles
+        _org_a, org_b, _org_c = orgs_with_roles
 
         # Change user's role in org_b from admin to owner
         mem = Membership.objects.get(user=user, organization=org_b)

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -7,6 +7,7 @@ after the model is properly implemented.
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError
 
 User = get_user_model()
 
@@ -82,7 +83,7 @@ class TestUserUniqueness:
 
     def test_duplicate_username_raises(self):
         User.objects.create_user(username="unique", password="pass123")
-        with pytest.raises(Exception):  # IntegrityError
+        with pytest.raises(IntegrityError):
             User.objects.create_user(username="unique", password="pass456")
 
     def test_duplicate_email_allowed(self):

--- a/config/api.py
+++ b/config/api.py
@@ -72,10 +72,7 @@ def service_error(request, exc):
 
 @api.exception_handler(DjangoValidationError)
 def django_validation_error(request, exc):
-    if hasattr(exc, "message_dict"):
-        detail = exc.message_dict
-    else:
-        detail = exc.messages
+    detail = exc.message_dict if hasattr(exc, "message_dict") else exc.messages
     return api.create_response(request, {"detail": detail}, status=422)
 
 

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,6 +1,6 @@
 """Development settings."""
 
-from config.settings.base import *  # noqa: F401, F403
+from config.settings.base import *  # noqa: F403
 
 DEBUG = True
 ALLOWED_HOSTS = ["*"]

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -2,7 +2,7 @@
 
 import os
 
-from config.settings.base import *  # noqa: F401, F403
+from config.settings.base import *  # noqa: F403
 
 DEBUG = False
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 
-from config.settings.base import *  # noqa: F401, F403
+from config.settings.base import *  # noqa: F403
 
 DEBUG = False
 

--- a/conftest.py
+++ b/conftest.py
@@ -67,4 +67,4 @@ def citizen(db, org):
 def auth_header_for_user(user) -> dict:
     """Get JWT auth header by creating a token directly (no HTTP round-trip)."""
     token = AccessToken.for_user(user)
-    return {"HTTP_AUTHORIZATION": f"Bearer {str(token)}"}
+    return {"HTTP_AUTHORIZATION": f"Bearer {token!s}"}

--- a/core/checks.py
+++ b/core/checks.py
@@ -1,7 +1,8 @@
 """Django system checks for security configuration."""
 
 from django.conf import settings
-from django.core.checks import Tags, Warning, register
+from django.core.checks import Tags, register
+from django.core.checks import Warning as DjangoWarning
 
 
 @register(Tags.security, deploy=True)
@@ -10,7 +11,7 @@ def check_cors_not_open(app_configs, **kwargs):
     errors = []
     if getattr(settings, "CORS_ALLOW_ALL_ORIGINS", False) and not settings.DEBUG:
         errors.append(
-            Warning(
+            DjangoWarning(
                 "CORS_ALLOW_ALL_ORIGINS is True while DEBUG is False.",
                 hint="Set CORS_ALLOW_ALL_ORIGINS = False and configure "
                 "CORS_ALLOWED_ORIGINS with explicit origins.",

--- a/core/tests/test_permissions.py
+++ b/core/tests/test_permissions.py
@@ -51,7 +51,7 @@ class TestCheckRole:
         org = Organization.objects.create(name="Test School")
         Membership.objects.create(user=user, organization=org, role=OrgRole.MEMBER)
 
-        allowed, msg = check_role(user, org.id, min_role=OrgRole.ADMIN)
+        allowed, _msg = check_role(user, org.id, min_role=OrgRole.ADMIN)
         assert allowed is False
 
     def test_owner_passes_admin_check(self):

--- a/core/validators.py
+++ b/core/validators.py
@@ -29,8 +29,8 @@ def validate_image_upload(file) -> str:
     try:
         Image.open(file).verify()
         file.seek(0)
-    except Exception:
-        raise BusinessValidationError("File is not a valid image.")
+    except Exception as e:
+        raise BusinessValidationError("File is not a valid image.") from e
 
     return mime_type
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,19 @@ line-length = 120
 exclude = ["**/migrations/**"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "S105", "S106", "S107"]
+select = ["E", "F", "I", "N", "W", "UP", "S105", "S106", "S107", "B", "A", "RUF", "SIM", "ARG"]
+ignore = [
+    "RUF012",  # Mutable ClassVar — Django Meta/ModelAdmin attrs are idiomatic without ClassVar
+]
 
 [tool.ruff.lint.per-file-ignores]
-"**/tests/**" = ["S105", "S106", "S107"]
-"**/conftest.py" = ["S105", "S106", "S107"]
-"**/factories.py" = ["S105", "S106", "S107"]
+"**/tests/**" = ["S105", "S106", "S107", "ARG"]
+"**/conftest.py" = ["S105", "S106", "S107", "ARG"]
+"**/factories.py" = ["S105", "S106", "S107", "ARG"]
 "core/management/commands/seed_dev_data.py" = ["S105", "S106", "S107"]
+"**/api.py" = ["ARG001"]  # request param required by Django Ninja even when unused
+"core/checks.py" = ["ARG001"]  # Django system check signature requires app_configs and **kwargs
+"core/management/commands/*.py" = ["ARG002"]  # Django management command signature requires *args/**options
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]


### PR DESCRIPTION
## Summary
- Adds B (bugbear), A (builtins), RUF, SIM, and ARG rule sets to ruff config, matching giraf-ai's expanded rules
- Fixes all 34 violations across 20 files — most notably adding proper exception chaining (`from e`) to all service-layer re-raises
- Configures per-file ignores for Django-idiomatic patterns (unused `request` in api.py, `*args/**options` in management commands, etc.)

## Changes by rule
| Rule | Count | Fix |
|------|-------|-----|
| B904 (missing `from` in re-raise) | 15 | Added `from e` or `from None` |
| B017 (blind `pytest.raises(Exception)`) | 2 | Replaced with `ValidationError`/`IntegrityError` |
| A004 (builtin shadow) | 1 | Renamed `Warning` → `DjangoWarning` |
| SIM108 (ternary) | 1 | Simplified if/else to ternary |
| RUF059 (unused unpack) | 5 | Prefixed with `_` |
| RUF100 (stale noqa) | 3 | Removed unused `F401` from noqa |
| RUF010 (str in f-string) | 1 | Used conversion flag |
| RUF012 (ClassVar on Django attrs) | — | Ignored globally |
| ARG (unused args) | — | Ignored per-file for tests/api/checks/commands |

## Test plan
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run pytest` — 262 tests passing, no regressions

Closes #30