### PR TITLE
chore: add C4 and PT ruff rule sets

### DIFF
--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -35,7 +35,7 @@ class TestUserCreation:
         assert user.is_superuser is False
 
     def test_create_user_without_username_raises(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="username"):
             User.objects.create_user(
                 username="",
                 email="test@example.com",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ line-length = 120
 exclude = ["**/migrations/**"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "S105", "S106", "S107", "B", "A", "RUF", "SIM", "ARG"]
+select = ["E", "F", "I", "N", "W", "UP", "S105", "S106", "S107", "B", "A", "RUF", "SIM", "ARG", "C4", "PT"]
 ignore = [
     "RUF012",  # Mutable ClassVar — Django Meta/ModelAdmin attrs are idiomatic without ClassVar
 ]


### PR DESCRIPTION
## Summary
- Adds flake8-comprehensions (C4) and flake8-pytest-style (PT) rule sets to ruff
- Fixes the single violation: adds `match="username"` to a bare `pytest.raises(ValueError)`

## Test plan
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run pytest` — 262 tests passing

Closes #37