### PR TITLE
refactor: use single subquery for get_user_organizations

### DIFF
--- a/apps/organizations/services.py
+++ b/apps/organizations/services.py
@@ -37,8 +37,9 @@ class OrganizationService:
     @staticmethod
     def get_user_organizations(user: User) -> QuerySet[Organization]:
         """Return organizations the user is a member of."""
-        org_ids = Membership.objects.filter(user=user).values_list("organization_id", flat=True)
-        return Organization.objects.filter(id__in=org_ids)
+        return Organization.objects.filter(
+            id__in=Membership.objects.filter(user=user).values("organization_id")
+        )
 
     @staticmethod
     def get_org_members(org_id: int) -> QuerySet[Membership]:


### PR DESCRIPTION
## Summary
- Replaces two separate DB queries with a single subquery in `OrganizationService.get_user_organizations()`
- Django generates `SELECT ... WHERE id IN (SELECT organization_id FROM ...)` — one round trip instead of two

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 263 passed, no regressions

Closes #31