### PR TITLE
refactor: add type hints to file upload parameters

### DIFF
--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -4,6 +4,7 @@ import logging
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
 from django.db.models import Q, QuerySet
 
@@ -147,10 +148,10 @@ class PictogramService:
     def upload_pictogram(
         *,
         name: str,
-        image,
+        image: UploadedFile,
         organization_id: int | None = None,
         citizen_id: int | None = None,
-        sound=None,
+        sound: UploadedFile | None = None,
         generate_sound: bool = True,
     ) -> Pictogram:
         """Upload a pictogram with an image file and optional sound file.
@@ -187,7 +188,7 @@ class PictogramService:
         image_url: str | None = None,
         generate_image: bool = False,
         regenerate_sound: bool = False,
-        sound=None,
+        sound: UploadedFile | None = None,
     ) -> Pictogram:
         """Update a pictogram's fields. Supports name, image_url, sound upload, and AI regeneration."""
         pictogram = PictogramService._get_pictogram_or_raise(pictogram_id)

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -7,6 +7,7 @@ import logging
 
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
 
 from apps.users.models import User
@@ -110,7 +111,7 @@ class UserService:
 
     @staticmethod
     @transaction.atomic
-    def upload_profile_picture(*, user_id: int, file) -> User:
+    def upload_profile_picture(*, user_id: int, file: UploadedFile) -> User:
         """Upload and validate profile picture.
 
         Raises:

--- a/core/validators.py
+++ b/core/validators.py
@@ -3,6 +3,7 @@
 import mimetypes
 import uuid
 
+from django.core.files.uploadedfile import UploadedFile
 from PIL import Image
 
 from core.exceptions import BusinessValidationError
@@ -11,7 +12,7 @@ ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"]
 MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB
 
 
-def validate_image_upload(file) -> str:
+def validate_image_upload(file: UploadedFile) -> str:
     """Validate an uploaded image file. Returns the detected MIME type.
 
     Checks extension-based MIME type, file size, and PIL image validity.
@@ -39,7 +40,7 @@ ALLOWED_AUDIO_TYPES = ["audio/mpeg"]
 MAX_AUDIO_SIZE = 10 * 1024 * 1024  # 10MB
 
 
-def validate_audio_file(file) -> str:
+def validate_audio_file(file: UploadedFile) -> str:
     """Validate an uploaded audio file. Returns the detected MIME type.
 
     Checks extension-based MIME type, file size, and MP3 frame header.


### PR DESCRIPTION
## Summary
- Adds `UploadedFile` type annotations to all untyped file parameters:
  - `core/validators.py` — `validate_image_upload(file)`, `validate_audio_file(file)`
  - `apps/pictograms/services.py` — `image`, `sound` in `upload_pictogram()` and `update_pictogram()`
  - `apps/users/services.py` — `file` in `upload_profile_picture()`

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 263 passed, no regressions

Closes #29