### PR TITLE
fix: add permission check to GET /pictograms/{id}

### DIFF
--- a/apps/pictograms/api.py
+++ b/apps/pictograms/api.py
@@ -124,10 +124,12 @@ def upload_sound(request, pictogram_id: int, sound: File[UploadedFile]):
     return 200, pictogram
 
 
-@router.get("/{pictogram_id}", response={200: PictogramOut, 404: ErrorOut})
+@router.get("/{pictogram_id}", response={200: PictogramOut, 403: ErrorOut, 404: ErrorOut})
 def get_pictogram(request, pictogram_id: int):
-    """Get a pictogram by ID."""
+    """Get a pictogram by ID. Org-scoped requires membership; global is open."""
     pictogram = PictogramService.get_pictogram(pictogram_id)
+    if pictogram.organization_id:
+        check_role_or_raise(request.auth, pictogram.organization_id, min_role=OrgRole.MEMBER)
     return 200, pictogram
 
 

--- a/apps/pictograms/tests/test_api.py
+++ b/apps/pictograms/tests/test_api.py
@@ -109,6 +109,24 @@ class TestPictogramAPI:
         assert response.status_code == 200
         assert "sound_url" in response.json()
 
+    def test_get_global_pictogram_no_org_check(self, client, non_member):
+        """Global pictograms (org=None) are accessible to any authenticated user."""
+        from apps.pictograms.models import Pictogram
+
+        p = Pictogram.objects.create(name="Global", image_url="https://g.com/g.png")
+        headers = auth_header_for_user(non_member)
+        response = client.get(f"/api/v1/pictograms/{p.id}", **headers)
+        assert response.status_code == 200
+
+    def test_get_org_pictogram_denied_for_non_member(self, client, org, non_member):
+        """Org-scoped pictograms require membership."""
+        from apps.pictograms.models import Pictogram
+
+        p = Pictogram.objects.create(name="Private", image_url="https://p.com/p.png", organization=org)
+        headers = auth_header_for_user(non_member)
+        response = client.get(f"/api/v1/pictograms/{p.id}", **headers)
+        assert response.status_code == 403
+
     def test_create_api_rejects_no_image_source(self, client, owner, org):
         headers = auth_header_for_user(owner)
         response = client.post(


### PR DESCRIPTION
## Summary
- `GET /pictograms/{id}` now checks membership for org-scoped pictograms
- Global pictograms (org=None) remain accessible to any authenticated user
- Adds two tests: non-member denied for org-scoped, non-member allowed for global

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 277 passed (2 new)

Closes #26