### PR TITLE
fix: remove super().save() hack in pictogram creation

### DIFF
--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -1,6 +1,7 @@
 """Business logic for pictogram operations."""
 
 import logging
+import uuid
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.base import ContentFile
@@ -84,7 +85,7 @@ class PictogramService:
         if generate_image:
             image_bytes = PictogramService._try_generate_image_bytes(name)
             if image_bytes:
-                image_content = ContentFile(image_bytes, name=f"{name}.png")
+                image_content = ContentFile(image_bytes, name=f"{uuid.uuid4().hex}.png")
 
         if not image_url and not image_content and generate_image:
             raise BusinessValidationError(

--- a/apps/pictograms/tests/test_services.py
+++ b/apps/pictograms/tests/test_services.py
@@ -75,11 +75,13 @@ class TestPictogramServiceCreate:
         assert not p.sound
 
     def test_create_with_generate_image_skips_gracefully(self):
-        """When AI is unavailable, create still succeeds without generated image."""
+        """When AI is unavailable, create still succeeds with image_url fallback."""
         p = PictogramService.create_pictogram(
             name="Test", image_url="https://example.com/img.png", generate_image=True, generate_sound=False
         )
         assert p.pk is not None
+        assert not p.image
+        assert p.image_url == "https://example.com/img.png"
 
     @patch("apps.pictograms.services.GirafAIClient")
     def test_create_with_generate_sound_calls_ai(self, mock_client):


### PR DESCRIPTION
## Summary

Restructures `create_pictogram()` to eliminate the `super(Pictogram, pictogram).save()` hack that bypassed `full_clean()`.

### Problem
The old code needed a PK before AI image generation (for `image.save(save=True)`), so it:
1. Called `super().save()` to bypass `full_clean()` and get a PK
2. Generated the image via AI
3. If AI failed, explicitly deleted the orphan row

This left invalid pictograms in the DB between steps 1 and 3, and the `@transaction.atomic` didn't help because the delete was a separate operation within the same transaction.

### Solution
1. New `_try_generate_image_bytes()` returns raw bytes (or `None`) — no DB required
2. `create_pictogram()` wraps bytes in `ContentFile`, passes to `Pictogram.objects.create()`
3. `full_clean()` runs naturally — no bypass, no orphans, no cleanup
4. `update_pictogram()` uses `image.save(save=False)` then `pictogram.save()` for the same pattern

### Key behavior changes
- `generate_image=True` without `image_url`: if AI fails, raises `BusinessValidationError` **before** any DB write (previously wrote then deleted)
- `generate_image=True` with `image_url`: if AI fails, pictogram is created with just the URL (unchanged)
- All paths now go through a single `Pictogram.objects.create()` call with `full_clean()`

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 280 passed (3 new regression tests)
- [x] New: AI success without URL → valid pictogram with image
- [x] New: AI failure without URL → raises, 0 rows in DB
- [x] New: No image source → model validation error, 0 rows in DB

Closes #25