### PR TITLE
refactor: add has_image_source property to Pictogram model

### DIFF
--- a/apps/pictograms/models.py
+++ b/apps/pictograms/models.py
@@ -47,6 +47,11 @@ class Pictogram(models.Model):
         return self.name
 
     @property
+    def has_image_source(self) -> bool:
+        """Whether this pictogram has any image (uploaded file or external URL)."""
+        return bool(self.image) or bool(self.image_url)
+
+    @property
     def effective_image_url(self) -> str:
         """Return uploaded image URL if available, otherwise the stored image_url."""
         if self.image:
@@ -61,7 +66,7 @@ class Pictogram(models.Model):
         return ""
 
     def clean(self):
-        if not self.image_url and not self.image:
+        if not self.has_image_source:
             raise ValidationError("A pictogram must have either an image_url or an uploaded image.")
         if self.citizen_id and not self.organization_id:
             raise ValidationError("A citizen-scoped pictogram must also have an organization.")

--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -87,7 +87,7 @@ class PictogramService:
             if image_bytes:
                 image_content = ContentFile(image_bytes, name=f"{uuid.uuid4().hex}.png")
 
-        if not image_url and not image_content and generate_image:
+        if generate_image and not image_url and not image_content:
             raise BusinessValidationError(
                 "Image generation failed and no image_url was provided."
             )

--- a/apps/pictograms/tests/test_models.py
+++ b/apps/pictograms/tests/test_models.py
@@ -55,6 +55,27 @@ class TestPictogramModel:
 
 
 @pytest.mark.django_db
+class TestPictogramHasImageSource:
+    def test_has_image_source_with_url(self):
+        from apps.pictograms.models import Pictogram
+
+        p = Pictogram(name="Test", image_url="https://example.com/pic.png")
+        assert p.has_image_source is True
+
+    def test_has_image_source_with_file(self):
+        from apps.pictograms.models import Pictogram
+
+        p = Pictogram(name="Test", image=make_test_image())
+        assert p.has_image_source is True
+
+    def test_has_image_source_with_neither(self):
+        from apps.pictograms.models import Pictogram
+
+        p = Pictogram(name="Test", image_url="", image=None)
+        assert p.has_image_source is False
+
+
+@pytest.mark.django_db
 class TestPictogramValidation:
     def test_pictogram_requires_image_source(self):
         from apps.pictograms.models import Pictogram


### PR DESCRIPTION
## Summary
- Adds `has_image_source` property to `Pictogram` model that encapsulates the dual-field check (`image_url` or `image`)
- Model's `clean()` now uses `has_image_source` instead of checking both fields separately
- Callers no longer need to know whether "no value" means `""` (CharField) or `NULL` (ImageField)
- Adds 3 tests for the new property (URL-only, file-only, neither)

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 290 passed (3 new)

Closes #33