### PR TITLE
fix: request wav format for TTS instead of mp3

### DIFF
--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -35,7 +35,7 @@ class PictogramService:
         try:
             client = GirafAIClient()
             audio_bytes = client.generate_tts(pictogram.name)
-            pictogram.sound.save(f"{pictogram.pk}.mp3", ContentFile(audio_bytes), save=True)
+            pictogram.sound.save(f"{pictogram.pk}.wav", ContentFile(audio_bytes), save=True)
         except GirafAIUnavailableError:
             logger.warning("giraf-ai unavailable — skipping TTS for pictogram %s", pictogram.pk)
         except Exception:

--- a/core/clients/giraf_ai.py
+++ b/core/clients/giraf_ai.py
@@ -72,6 +72,6 @@ class GirafAIClient:
         result = self._post("/api/v1/tts", {
             "text": text,
             "language": "da",
-            "format": "mp3",
+            "format": "wav",
         })
         return base64.b64decode(result["audio_base64"])


### PR DESCRIPTION
## Summary
Gemini TTS (the only remaining TTS provider) only supports wav output. The previous mp3 request caused `UnsupportedFormatError`.

- `core/clients/giraf_ai.py`: change `"format": "mp3"` to `"format": "wav"`
- `apps/pictograms/services.py`: change `.mp3` file extension to `.wav`
- 290 tests pass

Companion PR: aau-giraf/giraf-ai#34 removes the broken Google TTS adapter.