### PR TITLE
perf: make TTS generation fire-and-forget on pictogram upload

### DIFF
--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -1,9 +1,11 @@
 """Business logic for pictogram operations."""
 
 import logging
+import threading
 import uuid
 
 import httpx
+from django.conf import settings as django_settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import UploadedFile
@@ -34,6 +36,44 @@ class PictogramService:
             logger.warning("giraf-ai unavailable — skipping TTS for pictogram %s", pictogram.pk)
         except (httpx.HTTPError, ValueError, KeyError):
             logger.exception("Unexpected error generating TTS for pictogram %s", pictogram.pk)
+
+    @staticmethod
+    def _schedule_sound_generation(pictogram: Pictogram) -> None:
+        """Schedule TTS sound generation for a pictogram.
+
+        In production, defers to a background thread via transaction.on_commit
+        so the API response is not blocked.  In tests (TTS_SYNC=True), runs
+        synchronously to keep assertions deterministic.
+
+        If the thread fails or the server restarts, the pictogram simply has no
+        sound — caregivers can regenerate via the update endpoint.
+        """
+        if getattr(django_settings, "TTS_SYNC", False):
+            PictogramService._try_generate_sound(pictogram)
+            return
+
+        pk, name = pictogram.pk, pictogram.name
+
+        def _background() -> None:
+            try:
+                client = GirafAIClient()
+                audio_bytes = client.generate_tts(name)
+                p = Pictogram.objects.get(pk=pk)
+                p.sound.save(f"{pk}.wav", ContentFile(audio_bytes), save=True)
+            except Pictogram.DoesNotExist:
+                logger.warning("Pictogram %s deleted before TTS completed", pk)
+            except GirafAIUnavailableError:
+                logger.warning(
+                    "giraf-ai unavailable — skipping TTS for pictogram %s", pk
+                )
+            except (httpx.HTTPError, ValueError, KeyError):
+                logger.exception(
+                    "Unexpected error generating TTS for pictogram %s", pk
+                )
+
+        transaction.on_commit(
+            lambda: threading.Thread(target=_background, daemon=True).start()
+        )
 
     @staticmethod
     def _validate_citizen_org(citizen_id: int, organization_id: int | None) -> None:
@@ -98,7 +138,7 @@ class PictogramService:
             raise BusinessValidationError(" ".join(e.messages)) from e
 
         if generate_sound:
-            PictogramService._try_generate_sound(pictogram)
+            PictogramService._schedule_sound_generation(pictogram)
 
         return pictogram
 
@@ -167,7 +207,7 @@ class PictogramService:
         )
 
         if sound is None and generate_sound:
-            PictogramService._try_generate_sound(pictogram)
+            PictogramService._schedule_sound_generation(pictogram)
 
         return pictogram
 
@@ -204,7 +244,7 @@ class PictogramService:
         pictogram.save()
 
         if regenerate_sound and sound is None:
-            PictogramService._try_generate_sound(pictogram)
+            PictogramService._schedule_sound_generation(pictogram)
 
         return pictogram
 

--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -26,16 +26,19 @@ logger = logging.getLogger(__name__)
 
 class PictogramService:
     @staticmethod
-    def _try_generate_sound(pictogram: Pictogram) -> None:
-        """Attempt to generate TTS sound for a pictogram. Fails gracefully."""
+    def _generate_sound_for_pk(pk: int, name: str) -> None:
+        """Fetch a pictogram by PK and generate TTS sound. Fails gracefully."""
         try:
             client = GirafAIClient()
-            audio_bytes = client.generate_tts(pictogram.name)
-            pictogram.sound.save(f"{pictogram.pk}.wav", ContentFile(audio_bytes), save=True)
+            audio_bytes = client.generate_tts(name)
+            pictogram = Pictogram.objects.get(pk=pk)
+            pictogram.sound.save(f"{pk}.wav", ContentFile(audio_bytes), save=True)
+        except Pictogram.DoesNotExist:
+            logger.warning("Pictogram %s deleted before TTS completed", pk)
         except GirafAIUnavailableError:
-            logger.warning("giraf-ai unavailable — skipping TTS for pictogram %s", pictogram.pk)
+            logger.warning("giraf-ai unavailable — skipping TTS for pictogram %s", pk)
         except (httpx.HTTPError, ValueError, KeyError):
-            logger.exception("Unexpected error generating TTS for pictogram %s", pictogram.pk)
+            logger.exception("Unexpected error generating TTS for pictogram %s", pk)
 
     @staticmethod
     def _schedule_sound_generation(pictogram: Pictogram) -> None:
@@ -48,31 +51,18 @@ class PictogramService:
         If the thread fails or the server restarts, the pictogram simply has no
         sound — caregivers can regenerate via the update endpoint.
         """
-        if getattr(django_settings, "TTS_SYNC", False):
-            PictogramService._try_generate_sound(pictogram)
-            return
-
         pk, name = pictogram.pk, pictogram.name
 
-        def _background() -> None:
-            try:
-                client = GirafAIClient()
-                audio_bytes = client.generate_tts(name)
-                p = Pictogram.objects.get(pk=pk)
-                p.sound.save(f"{pk}.wav", ContentFile(audio_bytes), save=True)
-            except Pictogram.DoesNotExist:
-                logger.warning("Pictogram %s deleted before TTS completed", pk)
-            except GirafAIUnavailableError:
-                logger.warning(
-                    "giraf-ai unavailable — skipping TTS for pictogram %s", pk
-                )
-            except (httpx.HTTPError, ValueError, KeyError):
-                logger.exception(
-                    "Unexpected error generating TTS for pictogram %s", pk
-                )
+        if getattr(django_settings, "TTS_SYNC", False):
+            PictogramService._generate_sound_for_pk(pk, name)
+            return
 
         transaction.on_commit(
-            lambda: threading.Thread(target=_background, daemon=True).start()
+            lambda: threading.Thread(
+                target=PictogramService._generate_sound_for_pk,
+                args=(pk, name),
+                daemon=True,
+            ).start()
         )
 
     @staticmethod

--- a/apps/pictograms/services.py
+++ b/apps/pictograms/services.py
@@ -9,7 +9,7 @@ from django.conf import settings as django_settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import UploadedFile
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Q, QuerySet
 
 from apps.pictograms.models import Pictogram
@@ -27,7 +27,12 @@ logger = logging.getLogger(__name__)
 class PictogramService:
     @staticmethod
     def _generate_sound_for_pk(pk: int, name: str) -> None:
-        """Fetch a pictogram by PK and generate TTS sound. Fails gracefully."""
+        """Fetch a pictogram by PK and generate TTS sound. Fails gracefully.
+
+        When called from a background thread, the ``finally`` block closes the
+        DB connection so it is returned to the pool (Django tracks connections
+        per-thread and does not clean up daemon threads automatically).
+        """
         try:
             client = GirafAIClient()
             audio_bytes = client.generate_tts(name)
@@ -39,6 +44,8 @@ class PictogramService:
             logger.warning("giraf-ai unavailable — skipping TTS for pictogram %s", pk)
         except (httpx.HTTPError, ValueError, KeyError):
             logger.exception("Unexpected error generating TTS for pictogram %s", pk)
+        finally:
+            connection.close()
 
     @staticmethod
     def _schedule_sound_generation(pictogram: Pictogram) -> None:

--- a/apps/pictograms/tests/test_services.py
+++ b/apps/pictograms/tests/test_services.py
@@ -93,6 +93,7 @@ class TestPictogramServiceCreate:
         )
         assert p.pk is not None
         mock_instance.generate_tts.assert_called_once_with("AI Sound")
+        p.refresh_from_db()
         assert p.sound
 
     @patch("apps.pictograms.services.GirafAIClient")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -218,3 +218,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # ---------------------------------------------------------------------------
 
 GIRAF_AI_URL = os.environ.get("GIRAF_AI_URL", "")
+
+# When True, TTS generation runs synchronously instead of in a background
+# thread.  Enabled in tests to keep them deterministic.
+TTS_SYNC = False

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -26,3 +26,6 @@ NINJA_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(minutes=30),
     "SIGNING_KEY": SECRET_KEY,
 }
+
+# Run TTS synchronously so tests are deterministic (no background threads).
+TTS_SYNC = True


### PR DESCRIPTION
## Summary

- TTS generation (call to giraf-ai) no longer blocks the API response when creating/uploading pictograms
- Uses `transaction.on_commit()` + `threading.Thread(daemon=True)` — no new dependencies
- Sound is attached to the pictogram in the background; `sound_url` is `null` briefly after creation

## Approach

Evaluated Celery, Django-RQ, and bare threading. Chose `transaction.on_commit` + daemon thread because:
- Zero new dependencies (stdlib + Django built-in)
- Zero infrastructure changes (no new containers/workers)
- Appropriate for a single fire-and-forget task in a student project with semester handoffs
- TTS failure is already graceful — pictogram works without sound

## Changes

- `apps/pictograms/services.py` — Add `_schedule_sound_generation()` that defers TTS to a background thread after transaction commit. Update 3 call sites.
- `config/settings/base.py` — Add `TTS_SYNC = False`
- `config/settings/test.py` — Add `TTS_SYNC = True` (keeps tests synchronous/deterministic)
- `apps/pictograms/tests/test_services.py` — Add `refresh_from_db()` in TTS mock test

## Test plan

- [x] 316 tests passing (all existing + adjusted TTS test)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] TTS tests run synchronously via `TTS_SYNC=True`

Closes #68